### PR TITLE
Refactor tests

### DIFF
--- a/src/features/newGame/__test__/NavButton.test.tsx
+++ b/src/features/newGame/__test__/NavButton.test.tsx
@@ -5,68 +5,39 @@ import { act, cleanup, render, fireEvent, screen } from '@testing-library/react'
 import { DisplayContext } from '../context';
 import { NavButton } from '../NavButton';
 
-test('button calls the correct event based on direction prop', () => {
+test.each(['forward', 'back'])('bonus round checkbox click dispatches toggle action', direction => {
   const mockNext = jest.fn();
   const mockPrev = jest.fn();
-
-  interface test {
-    direction: 'forward' | 'back';
-    expectedHandler: () => void;
+  render(
+    <DisplayContext.Provider value={{ displayIdx: 0, next: mockNext, previous: mockPrev }}>
+      <NavButton direction={direction as 'forward' | 'back'}>a</NavButton>
+    </DisplayContext.Provider>,
+  );
+  const btn = screen.getByRole('button');
+  fireEvent.click(btn);
+  if (direction === 'forward') {
+    expect(mockNext).toHaveBeenCalled();
+  } else {
+    expect(mockPrev).toHaveBeenCalled();
   }
-
-  const tests: test[] = [
-    {
-      direction: 'forward',
-      expectedHandler: mockNext,
-    },
-    {
-      direction: 'back',
-      expectedHandler: mockPrev,
-    },
-  ];
-  tests.forEach(t => {
-    render(
-      <DisplayContext.Provider value={{ displayIdx: 0, next: mockNext, previous: mockPrev }}>
-        <NavButton direction={t.direction}>a</NavButton>
-      </DisplayContext.Provider>,
-    );
-    const btn = screen.getByRole('button');
-    fireEvent.click(btn);
-    expect(t.expectedHandler).toHaveBeenCalled();
-    cleanup();
-  });
+  cleanup();
 });
 
-test('button calls no event when the button is disabled', () => {
+test.each(['forward', 'back'])('button calls no event when the button is disabled', direction => {
   const mockNext = jest.fn();
   const mockPrev = jest.fn();
-
-  interface test {
-    direction: 'forward' | 'back';
-  }
-
-  const tests: test[] = [
-    {
-      direction: 'forward',
-    },
-    {
-      direction: 'back',
-    },
-  ];
-  tests.forEach(t => {
-    render(
-      <DisplayContext.Provider value={{ displayIdx: 0, next: mockNext, previous: mockPrev }}>
-        <NavButton direction={t.direction} disabled>
-          a
-        </NavButton>
-      </DisplayContext.Provider>,
-    );
-    const btn = screen.getByRole('button');
-    fireEvent.click(btn);
-    expect(mockNext).not.toHaveBeenCalled();
-    expect(mockPrev).not.toHaveBeenCalled();
-    cleanup();
-  });
+  render(
+    <DisplayContext.Provider value={{ displayIdx: 0, next: mockNext, previous: mockPrev }}>
+      <NavButton direction={direction as 'forward' | 'back'} disabled>
+        a
+      </NavButton>
+    </DisplayContext.Provider>,
+  );
+  const btn = screen.getByRole('button');
+  fireEvent.click(btn);
+  expect(mockNext).not.toHaveBeenCalled();
+  expect(mockPrev).not.toHaveBeenCalled();
+  cleanup();
 });
 
 test('button renders the correct children', () => {

--- a/src/features/newGame/__test__/NavButton.test.tsx
+++ b/src/features/newGame/__test__/NavButton.test.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
 
-import { act, render, fireEvent } from '@testing-library/react';
+import { act, cleanup, render, fireEvent, screen } from '@testing-library/react';
 
 import { DisplayContext } from '../context';
 import { NavButton } from '../NavButton';
-
-const cleanupDOM = () => {
-  document.getElementsByTagName('html')[0].innerHTML = '';
-};
 
 test('button calls the correct event based on direction prop', () => {
   const mockNext = jest.fn();
@@ -29,15 +25,15 @@ test('button calls the correct event based on direction prop', () => {
     },
   ];
   tests.forEach(t => {
-    const { getByRole } = render(
+    render(
       <DisplayContext.Provider value={{ displayIdx: 0, next: mockNext, previous: mockPrev }}>
         <NavButton direction={t.direction}>a</NavButton>
       </DisplayContext.Provider>,
     );
-    const btn = getByRole('button');
+    const btn = screen.getByRole('button');
     fireEvent.click(btn);
     expect(t.expectedHandler).toHaveBeenCalled();
-    cleanupDOM();
+    cleanup();
   });
 });
 
@@ -58,36 +54,36 @@ test('button calls no event when the button is disabled', () => {
     },
   ];
   tests.forEach(t => {
-    const { getByRole } = render(
+    render(
       <DisplayContext.Provider value={{ displayIdx: 0, next: mockNext, previous: mockPrev }}>
         <NavButton direction={t.direction} disabled>
           a
         </NavButton>
       </DisplayContext.Provider>,
     );
-    const btn = getByRole('button');
+    const btn = screen.getByRole('button');
     fireEvent.click(btn);
     expect(mockNext).not.toHaveBeenCalled();
     expect(mockPrev).not.toHaveBeenCalled();
-    cleanupDOM();
+    cleanup();
   });
 });
 
 test('button renders the correct children', () => {
   const testText = 'abc';
-  const { getByText } = render(<NavButton direction='forward'>{testText}</NavButton>);
-  getByText(testText);
+  render(<NavButton direction='forward'>{testText}</NavButton>);
+  screen.getByText(testText);
 });
 
 test('button calls the onclick handler if it is passed', () => {
   const testText = 'abc';
   const mockHandleClick = jest.fn();
-  const { getByText } = render(
+  render(
     <NavButton direction='forward' onClick={mockHandleClick}>
       {testText}
     </NavButton>,
   );
-  const button = getByText(testText);
+  const button = screen.getByText(testText);
   act(() => {
     fireEvent.click(button);
   });

--- a/src/features/newGame/__test__/NavButton.test.tsx
+++ b/src/features/newGame/__test__/NavButton.test.tsx
@@ -5,7 +5,7 @@ import { act, cleanup, render, fireEvent, screen } from '@testing-library/react'
 import { DisplayContext } from '../context';
 import { NavButton } from '../NavButton';
 
-test.each(['forward', 'back'])('bonus round checkbox click dispatches toggle action', direction => {
+test.each(['forward', 'back'])('button calls the correct event based on direction prop', direction => {
   const mockNext = jest.fn();
   const mockPrev = jest.fn();
   render(

--- a/src/features/newGame/__test__/NewGame.test.tsx
+++ b/src/features/newGame/__test__/NewGame.test.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
 
-import { act, render, wait, fireEvent } from '@testing-library/react';
+import { act, render, wait, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { NewGame } from '../NewGame';
 
 test('should be able to click through the screens and back', async () => {
-  const { getAllByPlaceholderText, getByText } = render(
-    <NewGame minPlayers={3} maxPlayers={10} handleCreateGame={jest.fn()} />,
-  );
-  expect(getByText(/enter player names/i)).toBeInTheDocument();
-  const playerNameInputs = getAllByPlaceholderText(/player \d+/i);
+  render(<NewGame minPlayers={3} maxPlayers={10} handleCreateGame={jest.fn()} />);
+  expect(screen.getByText(/enter player names/i)).toBeInTheDocument();
+  const playerNameInputs = screen.getAllByPlaceholderText(/player \d+/i);
   const names = ['a', 'b', 'c', 'd'];
-  const selectDealerButton = getByText(/select dealer/i);
+  const selectDealerButton = screen.getByText(/select dealer/i);
   for (let i = 0; i < playerNameInputs.length; i++) {
     await wait(async () => {
       await userEvent.type(playerNameInputs[i], names[i]);
@@ -21,25 +19,25 @@ test('should be able to click through the screens and back', async () => {
   await wait(() => {
     fireEvent.click(selectDealerButton);
   });
-  expect(getByText(/choose dealer/i)).toBeInTheDocument();
+  expect(screen.getByText(/choose dealer/i)).toBeInTheDocument();
   const dealer = names[0];
-  const chosenDealerButton = getByText(dealer);
-  const selectSettingsButton = getByText(/select settings/i);
+  const chosenDealerButton = screen.getByText(dealer);
+  const selectSettingsButton = screen.getByText(/select settings/i);
   act(() => {
     fireEvent.click(chosenDealerButton);
   });
   act(() => {
     fireEvent.click(selectSettingsButton);
   });
-  expect(getByText(/choose settings/i)).toBeInTheDocument();
+  expect(screen.getByText(/choose settings/i)).toBeInTheDocument();
 
   // now go backwards
   act(() => {
-    fireEvent.click(getByText(/select dealer/i));
+    fireEvent.click(screen.getByText(/select dealer/i));
   });
-  expect(getByText(/choose dealer/i)).toBeInTheDocument();
+  expect(screen.getByText(/choose dealer/i)).toBeInTheDocument();
   act(() => {
-    fireEvent.click(getByText(/player names/i));
+    fireEvent.click(screen.getByText(/player names/i));
   });
-  expect(getByText(/enter player names/i)).toBeInTheDocument();
+  expect(screen.getByText(/enter player names/i)).toBeInTheDocument();
 });

--- a/src/features/newGame/__test__/PlayerNamesForm.test.tsx
+++ b/src/features/newGame/__test__/PlayerNamesForm.test.tsx
@@ -13,8 +13,6 @@ const clearNamesButtonMatcher = /clear names/i;
 const inputPlaceholderRegex = /player \d+/i;
 const selectDealerButtonMatcher = /select dealer/i;
 
-// TODO test that the form cannot be submitted when there are duplicate names
-
 test('inputs are added one at a time until max is reached', async () => {
   const maxPlayers = 10;
 

--- a/src/features/newGame/__test__/PlayerNamesForm.test.tsx
+++ b/src/features/newGame/__test__/PlayerNamesForm.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, fireEvent, wait } from '@testing-library/react';
+import { render, fireEvent, screen, wait } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { NewGameContext } from '../context';
@@ -18,11 +18,11 @@ const selectDealerButtonMatcher = /select dealer/i;
 test('inputs are added one at a time until max is reached', async () => {
   const maxPlayers = 10;
 
-  const { getAllByPlaceholderText, getAllByRole } = render(<PlayerNamesForm minPlayers={3} maxPlayers={maxPlayers} />);
+  render(<PlayerNamesForm minPlayers={3} maxPlayers={maxPlayers} />);
 
-  const plus = getAllByRole('button')[plusBtnIdx];
+  const plus = screen.getAllByRole('button')[plusBtnIdx];
   const startingPlayers = 4;
-  const getInputs = () => getAllByPlaceholderText(inputPlaceholderRegex);
+  const getInputs = () => screen.getAllByPlaceholderText(inputPlaceholderRegex);
   const clickPlus = async () => {
     await wait(() => fireEvent.click(plus));
   };
@@ -42,11 +42,11 @@ test('inputs are added one at a time until max is reached', async () => {
 test('inputs are removed one at a time until min is reached', async () => {
   const minPlayers = 3;
 
-  const { getAllByPlaceholderText, getAllByRole } = render(<PlayerNamesForm minPlayers={minPlayers} maxPlayers={10} />);
+  render(<PlayerNamesForm minPlayers={minPlayers} maxPlayers={10} />);
 
-  const minus = getAllByRole('button')[minusBtnIdx];
+  const minus = screen.getAllByRole('button')[minusBtnIdx];
   const startingPlayers = 4;
-  const getInputs = () => getAllByPlaceholderText(inputPlaceholderRegex);
+  const getInputs = () => screen.getAllByPlaceholderText(inputPlaceholderRegex);
   const clickMinus = async () => {
     await wait(() => fireEvent.click(minus));
   };
@@ -64,12 +64,10 @@ test('inputs are removed one at a time until min is reached', async () => {
 });
 
 test('validation text appears when leaving an invalid field', async () => {
-  const { getAllByPlaceholderText, queryAllByText, queryByText } = render(
-    <PlayerNamesForm minPlayers={3} maxPlayers={10} />,
-  );
-  const getValidationMessages = () => queryAllByText(/name is required/i);
-  const inputs = getAllByPlaceholderText(inputPlaceholderRegex);
-  expect(queryByText(/name is required/i)).not.toBeInTheDocument();
+  render(<PlayerNamesForm minPlayers={3} maxPlayers={10} />);
+  const getValidationMessages = () => screen.queryAllByText(/name is required/i);
+  const inputs = screen.getAllByPlaceholderText(inputPlaceholderRegex);
+  expect(screen.queryByText(/name is required/i)).not.toBeInTheDocument();
   for (let i = 0; i < 1; i++) {
     await wait(() => {
       fireEvent.focus(inputs[i]);
@@ -83,9 +81,9 @@ test('validation text appears when leaving an invalid field', async () => {
 });
 
 test('select dealer button is disabled until all names are filled in', async () => {
-  const { getAllByPlaceholderText, getByText } = render(<PlayerNamesForm minPlayers={3} maxPlayers={10} />);
-  const submitBtn = getByText(selectDealerButtonMatcher);
-  const inputs = getAllByPlaceholderText(inputPlaceholderRegex);
+  render(<PlayerNamesForm minPlayers={3} maxPlayers={10} />);
+  const submitBtn = screen.getByText(selectDealerButtonMatcher);
+  const inputs = screen.getAllByPlaceholderText(inputPlaceholderRegex);
   // type in three inputs first
   for (let i = 0; i < inputs.length - 1; i++) {
     await wait(async () => {
@@ -101,9 +99,9 @@ test('select dealer button is disabled until all names are filled in', async () 
 });
 
 test('select dealer button is disabled if there are duplicate names', async () => {
-  const { getAllByPlaceholderText, getByText } = render(<PlayerNamesForm minPlayers={3} maxPlayers={10} />);
-  const submitBtn = getByText(selectDealerButtonMatcher);
-  const inputs = getAllByPlaceholderText(inputPlaceholderRegex);
+  render(<PlayerNamesForm minPlayers={3} maxPlayers={10} />);
+  const submitBtn = screen.getByText(selectDealerButtonMatcher);
+  const inputs = screen.getAllByPlaceholderText(inputPlaceholderRegex);
 
   for (let i = 0; i < inputs.length; i++) {
     await wait(async () => {
@@ -123,13 +121,13 @@ test('clear form button resets the form and clears the names in context', async 
   const mockState = initialState;
   const mockDispatch = jest.fn();
 
-  const { getByText, getAllByPlaceholderText, queryAllByDisplayValue } = render(
+  render(
     <NewGameContext.Provider value={{ state: mockState, dispatch: mockDispatch }}>
       <PlayerNamesForm minPlayers={3} maxPlayers={10} />,
     </NewGameContext.Provider>,
   );
-  const resetBtn = getByText(clearNamesButtonMatcher);
-  const inputs = getAllByPlaceholderText(inputPlaceholderRegex);
+  const resetBtn = screen.getByText(clearNamesButtonMatcher);
+  const inputs = screen.getAllByPlaceholderText(inputPlaceholderRegex);
   for (let i = 1; i < inputs.length; i++) {
     mockDispatch.mockClear();
     // fill in some inputs
@@ -138,11 +136,11 @@ test('clear form button resets the form and clears the names in context', async 
         await userEvent.type(inputs[j], `player${j}`);
       });
     }
-    expect(queryAllByDisplayValue(/player\d+/i)).toHaveLength(i);
+    expect(screen.queryAllByDisplayValue(/player\d+/i)).toHaveLength(i);
     await wait(() => {
       fireEvent.click(resetBtn);
     });
-    expect(queryAllByDisplayValue(/player\d+/i)).toHaveLength(0);
+    expect(screen.queryAllByDisplayValue(/player\d+/i)).toHaveLength(0);
     expect(mockDispatch).toHaveBeenCalledTimes(1);
     expect(mockDispatch).toHaveBeenLastCalledWith(actions.setPlayerNames([]));
   }
@@ -153,13 +151,13 @@ test('submit button should update context', async () => {
   const mockDispatch = jest.fn();
 
   const playerNames = ['q', 'w', 'e', 'r'];
-  const { getByText, getAllByPlaceholderText } = render(
+  render(
     <NewGameContext.Provider value={{ state: mockState, dispatch: mockDispatch }}>
       <PlayerNamesForm minPlayers={3} maxPlayers={10} />,
     </NewGameContext.Provider>,
   );
 
-  const inputs = getAllByPlaceholderText(inputPlaceholderRegex);
+  const inputs = screen.getAllByPlaceholderText(inputPlaceholderRegex);
   for (let i = 0; i < inputs.length; i++) {
     await wait(async () => {
       await userEvent.type(inputs[i], playerNames[i]);
@@ -167,7 +165,7 @@ test('submit button should update context', async () => {
   }
 
   await wait(() => {
-    fireEvent.click(getByText(/select dealer/i));
+    fireEvent.click(screen.getByText(/select dealer/i));
   });
 
   expect(mockDispatch).toHaveBeenCalledTimes(1);

--- a/src/features/newGame/__test__/PlusMinusButtonGroup.test.tsx
+++ b/src/features/newGame/__test__/PlusMinusButtonGroup.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 import PlusMinusButtonGroup from '../PlusMinusButtonGroup';
 
@@ -8,7 +8,7 @@ test('button event are fired and handled', () => {
   const mockOnIncrement = jest.fn();
   const mockOnDecrement = jest.fn();
 
-  const { getAllByRole } = render(
+  render(
     <PlusMinusButtonGroup
       onIncrement={mockOnIncrement}
       onDecrement={mockOnDecrement}
@@ -17,7 +17,7 @@ test('button event are fired and handled', () => {
     />,
   );
 
-  const btns = getAllByRole('button');
+  const btns = screen.getAllByRole('button');
   fireEvent.click(btns[0]);
   expect(mockOnIncrement).toHaveBeenCalledTimes(1);
   fireEvent.click(btns[1]);

--- a/src/features/newGame/__test__/SelectDealerForm.test.tsx
+++ b/src/features/newGame/__test__/SelectDealerForm.test.tsx
@@ -96,14 +96,14 @@ test('clicking back button dispatches unselectDealer', () => {
 
 test('submit button is disabled while no dealer is selected', () => {
   const names = getNames(4);
-  const {} = renderWithNames(names);
+  renderWithNames(names);
   const submitBtn = screen.getByText(submitButtonMatcher);
   expect(submitBtn).toBeDisabled();
 });
 
 test('submit button is disabled while dealer name is not in player names', () => {
   const names = getNames(4);
-  const {} = renderWithState({ ...initialState, playerNames: names, dealer: 'notAValidName' });
+  renderWithState({ ...initialState, playerNames: names, dealer: 'notAValidName' });
   const submitBtn = screen.getByText(submitButtonMatcher);
   expect(submitBtn).toBeDisabled();
 });

--- a/src/features/newGame/__test__/SettingExplainerWrapper.test.tsx
+++ b/src/features/newGame/__test__/SettingExplainerWrapper.test.tsx
@@ -1,27 +1,27 @@
 import React from 'react';
 
-import { act, render, fireEvent } from '@testing-library/react';
+import { act, render, fireEvent, screen } from '@testing-library/react';
 
 import { SettingExplainerWrapper } from '../SettingExplainerWrapper';
 
 test('wrapper should show text when the button is clicked', () => {
   const text = 'explainer text';
-  const { getByRole, getByText, queryByText } = render(
+  render(
     <SettingExplainerWrapper text={text}>
       <>asd</>
     </SettingExplainerWrapper>,
   );
-  const button = getByRole('button');
-  expect(queryByText(text)).not.toBeInTheDocument();
+  const button = screen.getByRole('button');
+  expect(screen.queryByText(text)).not.toBeInTheDocument();
   act(() => {
     fireEvent.click(button);
   });
-  expect(getByText(text)).toBeInTheDocument();
+  expect(screen.getByText(text)).toBeInTheDocument();
 });
 
 test('wrapper should render children', () => {
   const childText = 'child';
   const child = <React.Fragment>{childText}</React.Fragment>;
-  const { getByText } = render(<SettingExplainerWrapper text='asd'>{child}</SettingExplainerWrapper>);
-  expect(getByText(childText)).toBeInTheDocument();
+  render(<SettingExplainerWrapper text='asd'>{child}</SettingExplainerWrapper>);
+  expect(screen.getByText(childText)).toBeInTheDocument();
 });

--- a/src/features/newGame/__test__/SettingsForm.test.tsx
+++ b/src/features/newGame/__test__/SettingsForm.test.tsx
@@ -1,37 +1,30 @@
 import React from 'react';
 
-import { render, RenderResult, act, fireEvent } from '@testing-library/react';
+import { cleanup, render, act, fireEvent, screen } from '@testing-library/react';
 
 import { NewGameContext } from '../context';
 import { SettingsForm } from '../SettingsForm';
 import { initialState, actions } from '../slice';
 import { INewGameState, ScoringMode } from '../types';
 
-const cleanupDOM = () => {
-  document.getElementsByTagName('html')[0].innerHTML = '';
-};
-
 const renderWithSettings = (scoringMode: ScoringMode, bonusRounds: boolean) => {
   const state: INewGameState = { ...initialState, settings: { scoringMode, bonusRounds } };
   const mockDispatch = jest.fn();
 
-  const res: [RenderResult, () => void, INewGameState] = [
-    render(
-      <NewGameContext.Provider value={{ state, dispatch: mockDispatch }}>
-        <SettingsForm handleCreateGame={jest.fn()} />
-      </NewGameContext.Provider>,
-    ),
-    mockDispatch,
-    state,
-  ];
+  render(
+    <NewGameContext.Provider value={{ state, dispatch: mockDispatch }}>
+      <SettingsForm handleCreateGame={jest.fn()} />
+    </NewGameContext.Provider>,
+  );
+  const res: [() => void, INewGameState] = [mockDispatch, state];
   return res;
 };
 
 test('clicking the submit button should call handleCreateGame', () => {
   const mockHandleCreateGame = jest.fn();
-  const { getByText } = render(<SettingsForm handleCreateGame={mockHandleCreateGame} />);
+  render(<SettingsForm handleCreateGame={mockHandleCreateGame} />);
   act(() => {
-    fireEvent.click(getByText(/create game/i));
+    fireEvent.click(screen.getByText(/create game/i));
   });
   expect(mockHandleCreateGame).toHaveBeenCalled();
 });
@@ -51,10 +44,10 @@ test('scoring mode radio button check state is controlled by state', async () =>
   ];
 
   tests.forEach(t => {
-    const [{ getAllByLabelText }] = renderWithSettings(t.scoringMode, false);
-    t.standardRadioExpectation(getAllByLabelText(/standard scoring/i)[0]);
-    t.negativeRadioExpectation(getAllByLabelText(/negative scoring/i)[0]);
-    cleanupDOM();
+    renderWithSettings(t.scoringMode, false);
+    t.standardRadioExpectation(screen.getAllByLabelText(/standard scoring/i)[0]);
+    t.negativeRadioExpectation(screen.getAllByLabelText(/negative scoring/i)[0]);
+    cleanup();
   });
 });
 
@@ -72,14 +65,14 @@ test('scoring mode radio button clicks dispatch actions to update state', async 
     },
   ];
   tests.forEach(t => {
-    const [{ getByLabelText }, mockDispatch] = renderWithSettings(t.initialScoringMode, false);
-    const radio = getByLabelText(t.targetInputLabelMatcher);
+    const [mockDispatch] = renderWithSettings(t.initialScoringMode, false);
+    const radio = screen.getByLabelText(t.targetInputLabelMatcher);
     act(() => {
       fireEvent.click(radio);
     });
     expect(mockDispatch).toHaveBeenCalled();
     expect(mockDispatch).toHaveBeenLastCalledWith(t.expAction);
-    cleanupDOM();
+    cleanup();
   });
 });
 
@@ -95,10 +88,10 @@ test('bonus round checkbox state controlled by state', async () => {
     },
   ];
   tests.forEach(t => {
-    const [{ getByLabelText }] = renderWithSettings(ScoringMode.Negative, t.bonusRound);
-    const bonusCheckbox = getByLabelText(/use bonus rounds/i);
+    renderWithSettings(ScoringMode.Negative, t.bonusRound);
+    const bonusCheckbox = screen.getByLabelText(/use bonus rounds/i);
     t.expectation(bonusCheckbox);
-    cleanupDOM();
+    cleanup();
   });
 });
 
@@ -112,13 +105,13 @@ test('bonus round checkbox click dispatches toggle action', async () => {
     },
   ];
   tests.forEach(t => {
-    const [{ getByLabelText }, mockDispatch] = renderWithSettings(ScoringMode.Negative, t.bonusRound);
-    const bonusCheckbox = getByLabelText(/use bonus rounds/i);
+    const [mockDispatch] = renderWithSettings(ScoringMode.Negative, t.bonusRound);
+    const bonusCheckbox = screen.getByLabelText(/use bonus rounds/i);
     act(() => {
       fireEvent.click(bonusCheckbox);
     });
     expect(mockDispatch).toHaveBeenCalled();
     expect(mockDispatch).toHaveBeenLastCalledWith(actions.toggleBonusRounds());
-    cleanupDOM();
+    cleanup();
   });
 });

--- a/src/features/newGame/__test__/slice.test.ts
+++ b/src/features/newGame/__test__/slice.test.ts
@@ -36,27 +36,19 @@ test('reducer should clear dealer with unselectDealer action', () => {
   expect(newState.dealer).toBe('');
 });
 
-test('reducer should toggle bonus rounds setting with toggleBonusRounds action', () => {
+test.each([
+  [false, true],
+  [true, false],
+])('reducer should toggle bonus rounds setting with toggleBonusRounds action', (bonusRounds, expToggledValue) => {
   const getStateWithBonusRoundsSetTo = (br: boolean) => {
     const state: INewGameState = { ...initialState, settings: { ...initialState.settings, bonusRounds: br } };
     return state;
   };
-  const tests = [
-    {
-      bonusRounds: false,
-      expToggledValue: true,
-    },
-    {
-      bonusRounds: true,
-      expToggledValue: false,
-    },
-  ];
-  tests.forEach(t => {
-    const state = getStateWithBonusRoundsSetTo(t.bonusRounds);
-    expect(state.settings.bonusRounds).toBe(t.bonusRounds);
-    const newState = reducer(state, actions.toggleBonusRounds());
-    expect(newState.settings.bonusRounds).toBe(t.expToggledValue);
-  });
+
+  const state = getStateWithBonusRoundsSetTo(bonusRounds);
+  expect(state.settings.bonusRounds).toBe(bonusRounds);
+  const newState = reducer(state, actions.toggleBonusRounds());
+  expect(newState.settings.bonusRounds).toBe(expToggledValue);
 });
 
 test('reducer shouold set scoring mode with setScoringMode action', () => {


### PR DESCRIPTION
- Use `test.each` instead of `forEach`
- Use `screen` instead of destructuring the render result
- Use `cleanup` instead of writing our own